### PR TITLE
Update trunk February 2021

### DIFF
--- a/ara.opensciencegrid.org/trunk/README.md
+++ b/ara.opensciencegrid.org/trunk/README.md
@@ -10,13 +10,13 @@ This version is intended to represent the latest versions of all ARA software. I
 
 | Package            | Version/Commit   |
 | ------------------ | ---------------- |
-| CMake              | 3.18.2           |
-| FFTW               | 3.3.8            |
+| CMake              | 3.19.4           |
+| FFTW               | 3.3.9            |
 | GSL                | 2.6              |
-| SQLite             | 3330000          |
-| Boost              | 1.74.0           |
-| ROOT               | 6.22.02          |
-| Python             | 3.8.5            |
+| SQLite             | 3340100          |
+| Boost              | 1.75.0           |
+| ROOT               | 6.22.06          |
+| Python             | 3.9.1            |
 | LibRootFFTWWrapper | master           |
 | AraRoot            | master           |
 | AraSim             | master           |

--- a/builders/trunk/README.md
+++ b/builders/trunk/README.md
@@ -10,13 +10,13 @@ This version is intended to represent the latest versions of all ARA software. I
 
 | Package            | Version/Commit   |
 | ------------------ | ---------------- |
-| CMake              | 3.18.2           |
-| FFTW               | 3.3.8            |
+| CMake              | 3.19.2           |
+| FFTW               | 3.3.9            |
 | GSL                | 2.6              |
-| SQLite             | 3330000          |
-| Boost              | 1.74.0           |
-| ROOT               | 6.22.02          |
-| Python             | 3.8.5            |
+| SQLite             | 3340000          |
+| Boost              | 1.75.0           |
+| ROOT               | 6.22.06          |
+| Python             | 3.9.1            |
 | LibRootFFTWWrapper | master           |
 | AraRoot            | master           |
 | AraSim             | master           |

--- a/builders/trunk/README.md
+++ b/builders/trunk/README.md
@@ -10,10 +10,10 @@ This version is intended to represent the latest versions of all ARA software. I
 
 | Package            | Version/Commit   |
 | ------------------ | ---------------- |
-| CMake              | 3.19.2           |
+| CMake              | 3.19.4           |
 | FFTW               | 3.3.9            |
 | GSL                | 2.6              |
-| SQLite             | 3340000          |
+| SQLite             | 3340100          |
 | Boost              | 1.75.0           |
 | ROOT               | 6.22.06          |
 | Python             | 3.9.1            |

--- a/builders/trunk/build_CMake.sh
+++ b/builders/trunk/build_CMake.sh
@@ -3,8 +3,8 @@
 
 # Set script parameters
 PACKAGE_NAME="CMake"
-DOWNLOAD_LINK="https://github.com/Kitware/CMake/releases/download/v3.19.2/cmake-3.19.2.tar.gz"
-PACKAGE_DIR_NAME="cmake-3.19.2"
+DOWNLOAD_LINK="https://github.com/Kitware/CMake/releases/download/v3.19.2/cmake-3.19.4.tar.gz"
+PACKAGE_DIR_NAME="cmake-3.19.4"
 
 
 usage() {

--- a/builders/trunk/build_CMake.sh
+++ b/builders/trunk/build_CMake.sh
@@ -3,7 +3,7 @@
 
 # Set script parameters
 PACKAGE_NAME="CMake"
-DOWNLOAD_LINK="https://github.com/Kitware/CMake/releases/download/v3.19.2/cmake-3.19.4.tar.gz"
+DOWNLOAD_LINK="https://github.com/Kitware/CMake/releases/download/v3.19.4/cmake-3.19.4.tar.gz"
 PACKAGE_DIR_NAME="cmake-3.19.4"
 
 

--- a/builders/trunk/build_CMake.sh
+++ b/builders/trunk/build_CMake.sh
@@ -3,8 +3,8 @@
 
 # Set script parameters
 PACKAGE_NAME="CMake"
-DOWNLOAD_LINK="https://github.com/Kitware/CMake/releases/download/v3.18.2/cmake-3.18.2.tar.gz"
-PACKAGE_DIR_NAME="cmake-3.18.2"
+DOWNLOAD_LINK="https://github.com/Kitware/CMake/releases/download/v3.19.2/cmake-3.19.2.tar.gz"
+PACKAGE_DIR_NAME="cmake-3.19.2"
 
 
 usage() {

--- a/builders/trunk/build_FFTW.sh
+++ b/builders/trunk/build_FFTW.sh
@@ -3,8 +3,8 @@
 
 # Set script parameters
 PACKAGE_NAME="FFTW"
-DOWNLOAD_LINK="http://www.fftw.org/fftw-3.3.8.tar.gz"
-PACKAGE_DIR_NAME="fftw-3.3.8"
+DOWNLOAD_LINK="http://www.fftw.org/fftw-3.3.9.tar.gz"
+PACKAGE_DIR_NAME="fftw-3.3.9"
 
 
 usage() {

--- a/builders/trunk/build_ROOT6.sh
+++ b/builders/trunk/build_ROOT6.sh
@@ -3,8 +3,8 @@
 
 # Set script parameters
 PACKAGE_NAME="ROOT6"
-DOWNLOAD_LINK="https://root.cern/download/root_v6.22.02.source.tar.gz"
-PACKAGE_DIR_NAME="root-6.22.02"
+DOWNLOAD_LINK="https://root.cern/download/root_v6.22.06.source.tar.gz"
+PACKAGE_DIR_NAME="root-6.22.06"
 
 
 usage() {

--- a/builders/trunk/build_SQLite.sh
+++ b/builders/trunk/build_SQLite.sh
@@ -3,8 +3,8 @@
 
 # Set script parameters
 PACKAGE_NAME="SQLite"
-DOWNLOAD_LINK="https://www.sqlite.org/2020/sqlite-autoconf-3340000.tar.gz"
-PACKAGE_DIR_NAME="sqlite-autoconf-3340000"
+DOWNLOAD_LINK="https://www.sqlite.org/2020/sqlite-autoconf-3340100.tar.gz"
+PACKAGE_DIR_NAME="sqlite-autoconf-3340100"
 
 
 usage() {

--- a/builders/trunk/build_SQLite.sh
+++ b/builders/trunk/build_SQLite.sh
@@ -3,7 +3,7 @@
 
 # Set script parameters
 PACKAGE_NAME="SQLite"
-DOWNLOAD_LINK="https://www.sqlite.org/2020/sqlite-autoconf-3340100.tar.gz"
+DOWNLOAD_LINK="https://www.sqlite.org/2021/sqlite-autoconf-3340100.tar.gz"
 PACKAGE_DIR_NAME="sqlite-autoconf-3340100"
 
 

--- a/builders/trunk/build_SQLite.sh
+++ b/builders/trunk/build_SQLite.sh
@@ -3,8 +3,8 @@
 
 # Set script parameters
 PACKAGE_NAME="SQLite"
-DOWNLOAD_LINK="https://www.sqlite.org/2020/sqlite-autoconf-3330000.tar.gz"
-PACKAGE_DIR_NAME="sqlite-autoconf-3330000"
+DOWNLOAD_LINK="https://www.sqlite.org/2020/sqlite-autoconf-3340000.tar.gz"
+PACKAGE_DIR_NAME="sqlite-autoconf-3340000"
 
 
 usage() {

--- a/builders/trunk/build_boost.sh
+++ b/builders/trunk/build_boost.sh
@@ -3,8 +3,8 @@
 
 # Set script parameters
 PACKAGE_NAME="boost"
-DOWNLOAD_LINK="https://sourceforge.net/projects/boost/files/boost/1.74.0/boost_1_74_0.tar.gz"
-PACKAGE_DIR_NAME="boost_1_74_0"
+DOWNLOAD_LINK="https://sourceforge.net/projects/boost/files/boost/1.75.0/boost_1_75_0.tar.gz"
+PACKAGE_DIR_NAME="boost_1_75_0"
 
 
 usage() {

--- a/builders/trunk/build_libRootFftwWrapper.sh
+++ b/builders/trunk/build_libRootFftwWrapper.sh
@@ -137,7 +137,7 @@ if [ $SKIP_BUILD = false ]; then
 	echo "Compiling $PACKAGE_NAME"
 	cd "$PACKAGE_DIR_NAME"
 	sed -i 's:^find_package(FFTW REQUIRED):#find_package(FFTW REQUIRED)\
-set(FFTW_LIBRARIES "$ENV{FFTWSYS}/lib/libfftw3.so.3.5.8")\
+set(FFTW_LIBRARIES "$ENV{FFTWSYS}/lib/libfftw3.so.3.6.9")\
 set(FFTW_INCLUDES "$ENV{FFTWSYS}/include"):' CMakeLists.txt
 	sed -i 's:@ccmake:@cmake:' Makefile
 	make configure "$MAKE_ARG" || exit 31

--- a/builders/trunk/build_python3.sh
+++ b/builders/trunk/build_python3.sh
@@ -3,8 +3,8 @@
 
 # Set script parameters
 PACKAGE_NAME="python3"
-DOWNLOAD_LINK="https://www.python.org/ftp/python/3.8.5/Python-3.8.5.tgz"
-PACKAGE_DIR_NAME="py3.8.5"
+DOWNLOAD_LINK="https://www.python.org/ftp/python/3.9.1/Python-3.9.1.tgz"
+PACKAGE_DIR_NAME="py3.9.1"
 
 
 usage() {

--- a/builders/trunk/build_python3.sh
+++ b/builders/trunk/build_python3.sh
@@ -111,7 +111,7 @@ if [ $SKIP_BUILD = false ]; then
 
 	# pip install some needed python packages
 	export LD_LIBRARY_PATH="$BUILD_DIR/lib"
-	$BUILD_DIR/bin/pip3 install gnureadline h5py iminuit matplotlib numpy pandas pynverse scipy || exit 34
+	$BUILD_DIR/bin/pip3 install gnureadline h5py healpy iminuit matplotlib numpy pandas pynverse scipy || exit 34
 fi
 
 # Clean up source directory if requested


### PR DESCRIPTION
This bumps version on ~all dependencies (CMake, FFTW, SQLite, Boost, ROOT, and Python), and also adds healpy.