### PR TITLE
Add new frozen version: v3.0.0

### DIFF
--- a/ara.opensciencegrid.org/v3.0.0/README.md
+++ b/ara.opensciencegrid.org/v3.0.0/README.md
@@ -1,10 +1,10 @@
-# ara.opensciencegrid.org/trunk
+# ara.opensciencegrid.org/v3.0.0
 
-Static files for the trunk version of ARA software.
+Static files for version 3.0.0 of the ARA software.
 
 ## Version information
 
-This version is intended to represent the latest versions of all ARA software. It should also have the latest versions of dependencies where reasonable.
+This version of the ARA software was frozen in March 2021, representing the software stack as it was in January/February 2021.
 
 ### Package versions
 
@@ -16,12 +16,12 @@ This version is intended to represent the latest versions of all ARA software. I
 | SQLite             | 3340100          |
 | Boost              | 1.75.0           |
 | ROOT               | 6.22.06          |
-| Python             | 3.9.1            |
-| LibRootFFTWWrapper | master           |
-| AraRoot            | master           |
-| AraSim             | master           |
-| libnuphase         | master           |
-| nuphaseroot        | master           |
+| Python             | 3.8.5            |
+| LibRootFFTWWrapper | 24c667c          |
+| AraRoot            | ad39c3d          |
+| AraSim             | 99f2667          |
+| libnuphase         | 23d6615          |
+| nuphaseroot        | fa14899          |
 
 ## Contents
 

--- a/ara.opensciencegrid.org/v3.0.0/README.md
+++ b/ara.opensciencegrid.org/v3.0.0/README.md
@@ -1,0 +1,38 @@
+# ara.opensciencegrid.org/trunk
+
+Static files for the trunk version of ARA software.
+
+## Version information
+
+This version is intended to represent the latest versions of all ARA software. It should also have the latest versions of dependencies where reasonable.
+
+### Package versions
+
+| Package            | Version/Commit   |
+| ------------------ | ---------------- |
+| CMake              | 3.19.4           |
+| FFTW               | 3.3.9            |
+| GSL                | 2.6              |
+| SQLite             | 3340100          |
+| Boost              | 1.75.0           |
+| ROOT               | 6.22.06          |
+| Python             | 3.9.1            |
+| LibRootFFTWWrapper | master           |
+| AraRoot            | master           |
+| AraSim             | master           |
+| libnuphase         | master           |
+| nuphaseroot        | master           |
+
+## Contents
+
+This directory initially only contains static files which aren't build-dependent. However, this will be the destination for the trunk version of the ARA software on CVMFS. At that point it should contain the following:
+
+* setup.sh - A setup script which can be run to set all necessary paths to use this version of the software
+* source - A directory containing the source files of all packages listed above
+* ara\_build - A directory containing the compiled files of ARA-specific software
+* root\_build - A directory containing the compiled files of ROOT alone
+* misc\_build - A directory containing the compiled files of all other packages
+
+## Setup script
+
+The `setup.sh` script is designed to be `source`d by users of the ARA software to set the appropriate paths and other environment variables for working with the ARA software. Users of this version should run `source /cvmfs/ara.opensciencegrid.org/trunk/$OS/setup.sh` when setting up their environment, replacing `$OS` with their operating system.

--- a/ara.opensciencegrid.org/v3.0.0/README.md
+++ b/ara.opensciencegrid.org/v3.0.0/README.md
@@ -23,6 +23,19 @@ This version of the ARA software was frozen in March 2021, representing the soft
 | libnuphase         | 23d6615          |
 | nuphaseroot        | fa14899          |
 
+### Python packages
+
+The Python installation includes the following packages (along with any dependencies thereof):
+- gnureadline
+- h5py
+- healpy
+- iminuit
+- matplotlib
+- numpy
+- pandas
+- pynverse
+- scipy
+
 ## Contents
 
 This directory initially only contains static files which aren't build-dependent. However, this will be the destination for the trunk version of the ARA software on CVMFS. At that point it should contain the following:

--- a/ara.opensciencegrid.org/v3.0.0/ara_build/macros/ara_rootlogon.C
+++ b/ara.opensciencegrid.org/v3.0.0/ara_build/macros/ara_rootlogon.C
@@ -1,0 +1,22 @@
+{
+	gSystem->Load("libsqlite3.so");
+	gSystem->Load("libfftw3.so");
+	gSystem->Load("libgsl.so");
+	gSystem->Load("libMathMore.so");
+	gSystem->Load("libGeom.so");
+	gSystem->Load("libGraf3d.so");
+	gSystem->Load("libPhysics.so");
+	gSystem->Load("libRootFftwWrapper.so");
+	gSystem->Load("libAraEvent.so");
+	gSystem->Load("libAraConfig.so");
+	gSystem->Load("libAraDisplay.so");
+	gSystem->Load("libAraCorrelator.so");
+	gSystem->Load("libAraVertex.so");
+	gSystem->AddIncludePath("-I${ARA_UTIL_INSTALL_DIR}/include");
+	gSystem->AddIncludePath("-I${ARA_UTIL_INSTALL_DIR}/lib");
+	gSystem->AddIncludePath("-I${ARA_DEPS_INSTALL_DIR}/include");
+        gSystem->AddIncludePath("-I${ARA_DEPS_INSTALL_DIR}/lib");
+	gSystem->AddIncludePath("-I FFTtools.h");
+	gROOT->ProcessLine("#include <FFTtools.h>");
+
+}

--- a/ara.opensciencegrid.org/v3.0.0/setup.sh
+++ b/ara.opensciencegrid.org/v3.0.0/setup.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+# Setup script for trunk version of the ARA software
+
+export ARA_SETUP_DIR="/PATH/TO/THIS/SCRIPT"
+# If the fake path in ARA_SETUP_DIR wasn't replaced, try the working directory
+if [ ! -d "$ARA_SETUP_DIR" ]; then
+	export ARA_SETUP_DIR=$(pwd)
+fi
+
+export ARA_UTIL_INSTALL_DIR="${ARA_SETUP_DIR%/}/ara_build"
+export ARA_DEPS_INSTALL_DIR="${ARA_SETUP_DIR%/}/misc_build"
+export ARA_ROOT_DIR="${ARA_SETUP_DIR%/}/source/AraRoot"
+
+export LD_LIBRARY_PATH="$ARA_UTIL_INSTALL_DIR/lib:$ARA_DEPS_INSTALL_DIR/lib:$LD_LIBRARY_PATH"
+export DYLD_LIBRARY_PATH="$ARA_UTIL_INSTALL_DIR/lib:$ARA_DEPS_INSTALL_DIR/lib:$DYLD_LIBRARY_PATH"
+export PATH="$ARA_UTIL_INSTALL_DIR/bin:$ARA_DEPS_INSTALL_DIR/bin:$PATH"
+
+# Run thisroot.sh using `.` instead of `source` to improve POSIX compatibility
+. "${ARA_SETUP_DIR%/}/root_build/bin/thisroot.sh"
+
+export SQLITE_ROOT="$ARA_DEPS_INSTALL_DIR"
+export GSL_ROOT="$ARA_DEPS_INSTALL_DIR"
+#export FFTW_LIBRARIES="$ARA_DEPS_INSTALL_DIR"
+export FFTWSYS="$ARA_DEPS_INSTALL_DIR"
+
+export BOOST_ROOT="$ARA_DEPS_INSTALL_DIR/include"
+#export BOOST_LIB="$ARA_DEPS_INSTALL_DIR/lib"
+#export LD_LIBRARY_PATH="$BOOST_LIB:$LD_LIBRARY_PATH"
+#export DYLD_LIBRARY_PATH="$BOOST_LIB:$DYLD_LIBRARY_PATH"
+
+export CMAKE_PREFIX_PATH="$ARA_DEPS_INSTALL_DIR"
+
+export NUPHASE_INSTALL_DIR="$ARA_UTIL_INSTALL_DIR"
+
+# activate python environment
+#eval "$($ARA_DEPS_INSTALL_DIR/miniconda/bin/conda shell.bash hook)"
+
+
+# Warn about incompatible gcc versions
+export ARA_GCC_VERSION=$(strings -a "${ARA_SETUP_DIR%/}/source/AraSim/AraSim" | grep "GCC: (" | head -1 | cut -d " " -f 3)
+export SYS_GCC_VERSION=$($(command -v gcc) --version | head -1 | cut -d " " -f 3)
+if [ "$ARA_GCC_VERSION" = "4.8.5" ]; then
+	case $SYS_GCC_VERSION in
+		$ARA_GCC_VERSION )
+			# gcc version exactly matches the version used to compile AraSim
+			# (and presumably all other ARA software too then)
+		;;
+		4.* | 4.*.* )
+			# gcc version is between 4.0.0 and 5.0.0
+			echo "The ARA software was compiled with gcc version $ARA_GCC_VERSION."
+			echo "Your system uses gcc version $SYS_GCC_VERSION, which should be similar enough."
+		;;
+		[123].* | [123].*.* )
+			# gcc version is less than 4.0.0
+			echo "The ARA software was compiled with gcc version $ARA_GCC_VERSION."
+			echo "Your system uses gcc version $SYS_GCC_VERSION, which could result in some problems."
+			echo "Consider using a new version of gcc."
+		;;
+		* )
+			# gcc version is greater than 5.0.0
+			# (at which point the string ABI changed)
+			echo "The ARA software was compiled with gcc version $ARA_GCC_VERSION."
+			echo "Your system uses gcc version $SYS_GCC_VERSION, which is likely to cause problems."
+			echo "If you do any compilation against the ARA software you may need to add the '-D_GLIBCXX_USE_CXX11_ABI=0' flag."
+		;;
+	esac
+fi
+unset ARA_GCC_VERSION
+unset SYS_GCC_VERSION

--- a/builders/v2.0.0/README.md
+++ b/builders/v2.0.0/README.md
@@ -1,6 +1,6 @@
 # builders/v2.0.0
 
-Build scripts for the trunk version of the ARA software.
+Build scripts for version 2.0.0 of the ARA software.
 
 ## Version information
 

--- a/builders/v3.0.0/README.md
+++ b/builders/v3.0.0/README.md
@@ -1,0 +1,38 @@
+# builders/v3.0.0
+
+Build scripts for version 3.0.0 of the ARA software.
+
+## Version information
+
+This version of the ARA software was frozen in March 2021, representing the software stack as it was in January/February 2021.
+
+### Package versions
+
+| Package            | Version/Commit   |
+| ------------------ | ---------------- |
+| CMake              | 3.19.4           |
+| FFTW               | 3.3.9            |
+| GSL                | 2.6              |
+| SQLite             | 3340100          |
+| Boost              | 1.75.0           |
+| ROOT               | 6.22.06          |
+| Python             | 3.8.5            |
+| LibRootFFTWWrapper | 24c667c          |
+| AraRoot            | ad39c3d          |
+| AraSim             | 99f2667          |
+| libnuphase         | 23d6615          |
+| nuphaseroot        | fa14899          |
+
+## How to build software
+
+To build the entire ARA software stack, run `build.sh --dest DESTINATION_DIRECTORY` where `DESTINATION_DIRECTORY` is the directory where all the source and build files will be kept. There are additional options than can be passed to the script for more detailed installation:
+
+`build.sh --dest DESTINATION_DIRECTORY --dryrun` will perform a dryrun of the installation, creating a bare directory structure without downloading or installing any of the software.
+
+`build.sh --dest DESTINATION_DIRECTORY --make_arg -jX` will speed up any make commands by parallelizing across `X` subprocesses.
+
+
+## Building individual packages
+
+The `build.sh` script calls each of the individual `build_PROJECT.sh` scripts in the appropriate order. If for some reason you need to install just one of the projects, that should be possible using its respective build script in a fashion similar to `build.sh`. For more details you'll have to dig into the scripts.
+

--- a/builders/v3.0.0/README.md
+++ b/builders/v3.0.0/README.md
@@ -23,6 +23,19 @@ This version of the ARA software was frozen in March 2021, representing the soft
 | libnuphase         | 23d6615          |
 | nuphaseroot        | fa14899          |
 
+### Python packages
+
+The Python installation includes the following packages (along with any dependencies thereof):
+- gnureadline
+- h5py
+- healpy
+- iminuit
+- matplotlib
+- numpy
+- pandas
+- pynverse
+- scipy
+
 ## How to build software
 
 To build the entire ARA software stack, run `build.sh --dest DESTINATION_DIRECTORY` where `DESTINATION_DIRECTORY` is the directory where all the source and build files will be kept. There are additional options than can be passed to the script for more detailed installation:

--- a/builders/v3.0.0/build.sh
+++ b/builders/v3.0.0/build.sh
@@ -1,0 +1,141 @@
+#!/bin/sh
+# Build script for trunk version of ARA software
+
+
+usage() {
+	echo "usage: $0 [-h] [-d destination] [--make_arg argument] [--dryrun, --skip_download, --skip_build] [--clean_source]"
+	echo "  -h, --help                      display this help message"
+	echo "  -d, --dest destination          set the build destination directory"
+	echo "  --make_arg argument             additional argument to be passed to make"
+	echo "  --dryrun                        dryrun of all build scripts"
+	echo "  --skip_download                 skip download steps of build scripts"
+	echo "  --skip_build                    skip build steps of build scripts"
+	echo "  --clean_source                  remove unneeded source directories"
+}
+
+error() {
+	echo "$2"
+	exit "$1"
+}
+
+# Parse command line options
+SKIP_DOWNLOAD=false
+SKIP_BUILD=false
+while [ "$1" != "" ]; do
+	case $1 in
+		-h | --help )
+			usage
+			exit
+		;;
+		-d | --dest )
+			shift
+			DEST="$1"
+		;;
+		--make_arg )
+			shift
+			MAKE_ARG="--make_arg $1"
+		;;
+		--dryrun )
+			SKIP_DOWNLOAD=true
+			SKIP_BUILD=true
+		;;
+		--skip_download )
+			SKIP_DOWNLOAD=true
+		;;
+		--skip_build )
+			SKIP_BUILD=true
+		;;
+		--clean_source)
+			CLEAN_SOURCE="--clean_source"
+		;;
+		* )
+			usage
+			exit 1
+		;;
+	esac
+	shift
+done
+
+if [ ! -d "$DEST" ]; then
+	echo "Invalid destination directory: $DEST"
+	exit 2
+fi
+
+DEST=$(cd "$DEST" && pwd)
+
+SKIP_ARG=""
+if [ $SKIP_DOWNLOAD = true ]; then
+	SKIP_ARG="$SKIP_ARG --skip_download"
+fi
+if [ $SKIP_BUILD = true ]; then
+	SKIP_ARG="$SKIP_ARG --skip_build"
+fi
+
+# Don't clean source directories in a dry run
+if ([ $SKIP_DOWNLOAD = true ] && [ $SKIP_BUILD = true ]); then
+	CLEAN_SOURCE=""
+fi
+
+# Discover the directory containing this script
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+
+# Look for expected build tools
+TOOLS="make gcc"
+MISSING=0
+echo "Searching for expected build tools..."
+for TOOL in $TOOLS; do
+	if [ $(command -v $TOOL) ]; then
+		echo "$(command -v $TOOL) found: $($TOOL --version | head -1)"
+	else
+		echo "$TOOL NOT found"
+		MISSING=$(($MISSING + 1))
+	fi
+done
+if [ $MISSING -eq 0 ]; then
+	echo "Found all expected build tools"
+else
+	echo "Missing $MISSING expected build tools, continuing anyway"
+fi
+
+echo "Building to $DEST"
+
+# Create the required source and build directories
+SOURCE_DIR="${DEST%/}/source/"
+ARA_BUILD_DIR="${DEST%/}/ara_build/"
+DEPS_BUILD_DIR="${DEST%/}/misc_build/"
+ROOT_BUILD_DIR="${DEST%/}/root_build/"
+if [ ! -d "$SOURCE_DIR" ]; then
+	mkdir "$SOURCE_DIR"
+fi
+if [ ! -d "$ARA_BUILD_DIR" ]; then
+	mkdir "$ARA_BUILD_DIR"
+fi
+if [ ! -d "$DEPS_BUILD_DIR" ]; then
+	mkdir "$DEPS_BUILD_DIR"
+fi
+if [ ! -d "$ROOT_BUILD_DIR" ]; then
+	mkdir "$ROOT_BUILD_DIR"
+fi
+
+# Run build scripts from this script's directory
+cd "$SCRIPT_DIR"
+./build_CMake.sh --source "$SOURCE_DIR" --build "$DEPS_BUILD_DIR" $MAKE_ARG $SKIP_ARG $CLEAN_SOURCE || error 101 "Failed CMake build"
+./build_FFTW.sh --source "$SOURCE_DIR" --build "$DEPS_BUILD_DIR" $MAKE_ARG $SKIP_ARG $CLEAN_SOURCE || error 102 "Failed FFTW build"
+./build_GSL.sh --source "$SOURCE_DIR" --build "$DEPS_BUILD_DIR" $MAKE_ARG $SKIP_ARG $CLEAN_SOURCE || error 103 "Failed GSL build"
+./build_SQLite.sh --source "$SOURCE_DIR" --build "$DEPS_BUILD_DIR" $MAKE_ARG $SKIP_ARG $CLEAN_SOURCE || error 104 "Failed SQLite build"
+./build_python3.sh --source "$SOURCE_DIR" --build "$DEPS_BUILD_DIR" $MAKE_ARG $SKIP_ARG $CLEAN_SOURCE || error 105 "Failed python3 build"
+./build_boost.sh --source "$SOURCE_DIR" --build "$DEPS_BUILD_DIR" $MAKE_ARG $SKIP_ARG $CLEAN_SOURCE || error 106 "Failed boost build"
+./build_ROOT6.sh --source "$SOURCE_DIR" --build "$ROOT_BUILD_DIR" --deps "$DEPS_BUILD_DIR" $MAKE_ARG $SKIP_ARG $CLEAN_SOURCE || error 107 "Failed ROOT6 build"
+./build_libRootFftwWrapper.sh --source "$SOURCE_DIR" --build "$DEPS_BUILD_DIR" --root "$ROOT_BUILD_DIR" --deps "$DEPS_BUILD_DIR" $MAKE_ARG $SKIP_ARG || error 108 "Failed libRootFftwWrapper build"
+./build_AraRoot.sh --source "$SOURCE_DIR" --build "$ARA_BUILD_DIR" --root "$ROOT_BUILD_DIR" --deps "$DEPS_BUILD_DIR" $SKIP_ARG || error 109 "Failed AraRoot build"
+./build_AraSim.sh --source "$SOURCE_DIR" --build "$ARA_BUILD_DIR" --root "$ROOT_BUILD_DIR" --deps "$DEPS_BUILD_DIR" $MAKE_ARG $SKIP_ARG || error 110 "Failed AraSim build"
+./build_libnuphase.sh --source "$SOURCE_DIR" --build "$ARA_BUILD_DIR" --root "$ROOT_BUILD_DIR" --deps "$DEPS_BUILD_DIR" $SKIP_ARG || error 111 "Failed libnuphase build"
+./build_nuphaseroot.sh --source "$SOURCE_DIR" --build "$ARA_BUILD_DIR" --root "$ROOT_BUILD_DIR" --deps "$DEPS_BUILD_DIR" $SKIP_ARG || error 112 "Failed nuphaseroot build"
+
+# Hardcode destination path in the setup script
+if [ $SKIP_BUILD = false ]; then
+	echo "Recording installation path in setup script"
+	sed -i s:/PATH/TO/THIS/SCRIPT:$DEST: "$DEST/setup.sh"
+fi
+
+echo "Finished building ARA software"

--- a/builders/v3.0.0/build_AraRoot.sh
+++ b/builders/v3.0.0/build_AraRoot.sh
@@ -1,0 +1,148 @@
+#!/bin/sh
+# Build script for AraRoot
+
+# Set script parameters
+PACKAGE_NAME="AraRoot"
+DOWNLOAD_LINK="https://github.com/ara-software/AraRoot/archive/ad39c3d7b3ab6c9ac6f7f4f57d77a376c7f9f600.tar.gz"
+PACKAGE_DIR_NAME="AraRoot"
+
+
+usage() {
+	echo "usage: $0 [-h] [-d destination] [-s destination] [-b destination] [-r directory] [--deps directory] [--skip_download, --skip_build] [--clean_source]"
+	echo "  -h, --help                      display this help message"
+	echo "  -d, --dest destination          set the destination directory (containing source and build directories)"
+	echo "  -s, --source destination        set the source destination directory"
+	echo "  -b, --build destination         set the build destination directory"
+	echo "  -r, --root directory            set the root build directory"
+	echo "  --deps directory                set the dependency build directory"
+	echo "  --skip_download                 $PACKAGE_NAME exists pre-downloaded at the source destination"
+	echo "  --skip_build                    $PACKAGE_NAME has already been built at the build destination"
+	echo "  --clean_source                  remove source directory after build"
+}
+
+# Parse command line options
+SKIP_DOWNLOAD=false
+SKIP_BUILD=false
+CLEAN_SOURCE=false
+while [ "$1" != "" ]; do
+	case $1 in
+		-h | --help )
+			usage
+			exit
+		;;
+		-d | --dest )
+			shift
+			DEST="$1"
+		;;
+		-s | --source )
+			shift
+			SOURCE_DIR="$1"
+		;;
+		-b | --build )
+			shift
+			BUILD_DIR="$1"
+		;;
+		-r | --root )
+			shift
+			ROOT_BUILD_DIR="$1"
+		;;
+		--deps )
+			shift
+			DEPS_BUILD_DIR="$1"
+		;;
+		--skip_download )
+			SKIP_DOWNLOAD=true
+		;;
+		--skip_build )
+			SKIP_BUILD=true
+		;;
+		--clean_source)
+			CLEAN_SOURCE=true
+		;;
+		* )
+			usage
+			exit 1
+		;;
+	esac
+	shift
+done
+
+if [ "$DEST" != "" ]; then
+	if [ -z "$SOURCE_DIR" ]; then
+		SOURCE_DIR="${DEST%/}/source/"
+	fi
+	if [ -z "$BUILD_DIR" ]; then
+		BUILD_DIR="${DEST%/}/build/"
+	fi
+fi
+
+if [ -z "$DEPS_BUILD_DIR" ]; then
+	DEPS_BUILD_DIR="$BUILD_DIR"
+fi
+
+if [ -z "$ROOT_BUILD_DIR" ]; then
+	ROOT_BUILD_DIR="$BUILD_DIR"
+fi
+
+if [ ! -d "$SOURCE_DIR" ]; then
+	echo "Invalid source destination directory: $SOURCE_DIR"
+	exit 2
+fi
+if [ ! -d "$BUILD_DIR" ]; then
+	echo "Invalid build destination directory: $BUILD_DIR"
+	exit 3
+fi
+if [ ! -d "$DEPS_BUILD_DIR" ]; then
+	echo "Invalid dependency build directory: $DEPS_BUILD_DIR"
+	exit 4
+fi
+if [ ! -d "$ROOT_BUILD_DIR" ]; then
+	echo "Invalid root build directory: $ROOT_BUILD_DIR"
+	exit 5
+fi
+
+
+# Download and unzip the package
+cd "$SOURCE_DIR"
+if [ $SKIP_DOWNLOAD = false ]; then
+	echo "Downloading $PACKAGE_NAME to $SOURCE_DIR"
+	wget "$DOWNLOAD_LINK" -O "$PACKAGE_DIR_NAME.tar.gz" || exit 11
+	echo "Extracting $PACKAGE_NAME"
+	mkdir "$PACKAGE_DIR_NAME"
+	tar -xzf "$PACKAGE_DIR_NAME.tar.gz" -C "$PACKAGE_DIR_NAME" --strip-components=1 || exit 12
+	rm "$PACKAGE_DIR_NAME.tar.gz"
+fi
+
+# Set required environment variables
+if [ $SKIP_BUILD = false ]; then
+	export ARA_UTIL_INSTALL_DIR="${BUILD_DIR%/}"
+	export ARA_DEPS_INSTALL_DIR="${DEPS_BUILD_DIR%/}"
+	export ARA_ROOT_DIR="${SOURCE_DIR%/}/$PACKAGE_DIR_NAME"
+	export LD_LIBRARY_PATH="$ARA_DEPS_INSTALL_DIR/lib:$LD_LIBRARY_PATH"
+	export DYLD_LIBRARY_PATH="$ARA_DEPS_INSTALL_DIR/lib:$DYLD_LIBRARY_PATH"
+	export PATH="$ARA_DEPS_INSTALL_DIR/bin:$PATH"
+	. "${ROOT_BUILD_DIR%/}"/bin/thisroot.sh || exit 21
+	export SQLITE_ROOT="$ARA_DEPS_INSTALL_DIR"
+	export GSL_ROOT="$ARA_DEPS_INSTALL_DIR"
+	export FFTWSYS="$ARA_DEPS_INSTALL_DIR"
+	export CMAKE_PREFIX_PATH="$ARA_DEPS_INSTALL_DIR"
+fi
+
+# Run package installation
+if [ $SKIP_BUILD = false ]; then
+	echo "Compiling $PACKAGE_NAME"
+	cd "$PACKAGE_DIR_NAME"
+	sed -i 's:#set(CMAKE_CXX_STANDARD 11):set(CMAKE_CXX_STANDARD 11):' CMakeLists.txt
+	bash INSTALL.sh 1 || exit 31
+	echo "Adjusting ROOT's system.rootrc for $PACKAGE_NAME"
+	sed -i 's:\(Rint.Logon\:\s*\)rootlogon.C:\1$(ARA_UTIL_INSTALL_DIR)/macros/ara_rootlogon.C:' "${ROOT_BUILD_DIR%/}/etc/system.rootrc"
+fi
+
+# Clean up source directory if requested
+if [ $CLEAN_SOURCE = true ]; then
+	echo "Removing $PACKAGE_NAME source directory from $SOURCE_DIR"
+	cd "$SOURCE_DIR"
+	rm -rf "$PACKAGE_DIR_NAME"
+fi
+
+echo "$PACKAGE_NAME installed in $BUILD_DIR"

--- a/builders/v3.0.0/build_AraSim.sh
+++ b/builders/v3.0.0/build_AraSim.sh
@@ -1,0 +1,152 @@
+#!/bin/sh
+# Build script for AraSim
+
+# Set script parameters
+PACKAGE_NAME="AraSim"
+DOWNLOAD_LINK="https://github.com/ara-software/AraSim/archive/99f26671ea6590624872d3a76c43da2dbebe1006.tar.gz"
+PACKAGE_DIR_NAME="AraSim"
+
+
+usage() {
+	echo "usage: $0 [-h] [-d destination] [-s destination] [-b destination] [-r directory] [--deps directory] [--make_arg argument] [--skip_download, --skip_build] [--clean_source]"
+	echo "  -h, --help                      display this help message"
+	echo "  -d, --dest destination          set the destination directory (containing source and build directories)"
+	echo "  -s, --source destination        set the source destination directory"
+	echo "  -b, --build destination         set the build destination directory"
+	echo "  -r, --root directory            set the root build directory"
+	echo "  --deps directory                set the dependency build directory"
+	echo "  --make_arg argument             additional argument to be passed to make"
+	echo "  --skip_download                 $PACKAGE_NAME exists pre-downloaded at the source destination"
+	echo "  --skip_build                    $PACKAGE_NAME has already been built at the build destination"
+	echo "  --clean_source                  remove source directory after build"
+}
+
+# Parse command line options
+SKIP_DOWNLOAD=false
+SKIP_BUILD=false
+CLEAN_SOURCE=false
+while [ "$1" != "" ]; do
+	case $1 in
+		-h | --help )
+			usage
+			exit
+		;;
+		-d | --dest )
+			shift
+			DEST="$1"
+		;;
+		-s | --source )
+			shift
+			SOURCE_DIR="$1"
+		;;
+		-b | --build )
+			shift
+			BUILD_DIR="$1"
+		;;
+		-r | --root )
+			shift
+			ROOT_BUILD_DIR="$1"
+		;;
+		--deps )
+			shift
+			DEPS_BUILD_DIR="$1"
+		;;
+		--skip_download )
+			SKIP_DOWNLOAD=true
+		;;
+		--skip_build )
+			SKIP_BUILD=true
+		;;
+		--make_arg )
+			shift
+			MAKE_ARG="$1"
+		;;
+		--clean_source)
+			CLEAN_SOURCE=true
+		;;
+		* )
+			usage
+			exit 1
+		;;
+	esac
+	shift
+done
+
+if [ "$DEST" != "" ]; then
+	if [ -z "$SOURCE_DIR" ]; then
+		SOURCE_DIR="${DEST%/}/source/"
+	fi
+	if [ -z "$BUILD_DIR" ]; then
+		BUILD_DIR="${DEST%/}/build/"
+	fi
+fi
+
+if [ -z "$DEPS_BUILD_DIR" ]; then
+	DEPS_BUILD_DIR="$BUILD_DIR"
+fi
+
+if [ -z "$ROOT_BUILD_DIR" ]; then
+	ROOT_BUILD_DIR="$BUILD_DIR"
+fi
+
+if [ ! -d "$SOURCE_DIR" ]; then
+	echo "Invalid source destination directory: $SOURCE_DIR"
+	exit 2
+fi
+if [ ! -d "$BUILD_DIR" ]; then
+	echo "Invalid build destination directory: $BUILD_DIR"
+	exit 3
+fi
+if [ ! -d "$DEPS_BUILD_DIR" ]; then
+	echo "Invalid dependency build directory: $DEPS_BUILD_DIR"
+	exit 4
+fi
+if [ ! -d "$ROOT_BUILD_DIR" ]; then
+	echo "Invalid root build directory: $ROOT_BUILD_DIR"
+	exit 5
+fi
+
+
+# Download and unzip the package
+cd "$SOURCE_DIR"
+if [ $SKIP_DOWNLOAD = false ]; then
+	echo "Downloading $PACKAGE_NAME to $SOURCE_DIR"
+	wget "$DOWNLOAD_LINK" -O "$PACKAGE_DIR_NAME.tar.gz" || exit 11
+	echo "Extracting $PACKAGE_NAME"
+	mkdir "$PACKAGE_DIR_NAME"
+	tar -xzf "$PACKAGE_DIR_NAME.tar.gz" -C "$PACKAGE_DIR_NAME" --strip-components=1 || exit 12
+	rm "$PACKAGE_DIR_NAME.tar.gz"
+fi
+
+# Set required environment variables
+if [ $SKIP_BUILD = false ]; then
+	export ARA_UTIL_INSTALL_DIR="${BUILD_DIR%/}"
+	export ARA_DEPS_INSTALL_DIR="${DEPS_BUILD_DIR%/}"
+	export ARA_ROOT_DIR="${SOURCE_DIR%/}/AraRoot"
+	export LD_LIBRARY_PATH="$ARA_DEPS_INSTALL_DIR/lib:$LD_LIBRARY_PATH"
+	export DYLD_LIBRARY_PATH="$ARA_DEPS_INSTALL_DIR/lib:$DYLD_LIBRARY_PATH"
+	export PATH="$ARA_DEPS_INSTALL_DIR/bin:$PATH"
+	. "${ROOT_BUILD_DIR%/}"/bin/thisroot.sh || exit 21
+	export BOOST_ROOT="$ARA_DEPS_INSTALL_DIR/include"
+fi
+
+# Run package installation
+if [ $SKIP_BUILD = false ]; then
+	echo "Compiling $PACKAGE_NAME"
+	cd "$PACKAGE_DIR_NAME"
+	make "$MAKE_ARG" || exit 31
+	# cp AraSim "${BUILD_DIR%/}/bin/AraSim" # (Removed since AraSim can't be run from outside the source directory)
+	cp libAra.so "${BUILD_DIR%/}/lib/libAra.so"
+	cp eventSimDict_rdict.pcm "${BUILD_DIR%/}/lib/eventSimDict_rdict.pcm"
+	make "$MAKE_ARG" -f M.readTree || exit 32
+	make "$MAKE_ARG" -f M.readGeom || exit 33
+fi
+
+# Clean up source directory if requested
+if [ $CLEAN_SOURCE = true ]; then
+	echo "Removing $PACKAGE_NAME source directory from $SOURCE_DIR"
+	cd "$SOURCE_DIR"
+	rm -rf "$PACKAGE_DIR_NAME"
+fi
+
+echo "$PACKAGE_NAME installed in $BUILD_DIR"

--- a/builders/v3.0.0/build_CMake.sh
+++ b/builders/v3.0.0/build_CMake.sh
@@ -1,0 +1,112 @@
+#!/bin/sh
+# Build script for CMake
+
+# Set script parameters
+PACKAGE_NAME="CMake"
+DOWNLOAD_LINK="https://github.com/Kitware/CMake/releases/download/v3.19.4/cmake-3.19.4.tar.gz"
+PACKAGE_DIR_NAME="cmake-3.19.4"
+
+
+usage() {
+	echo "usage: $0 [-h] [-d destination] [-s destination] [-b destination] [--make_arg argument] [--skip_download, --skip_build] [--clean_source]"
+	echo "  -h, --help                      display this help message"
+	echo "  -d, --dest destination          set the destination directory (containing source and build directories)"
+	echo "  -s, --source destination        set the source destination directory"
+	echo "  -b, --build destination         set the build destination directory"
+	echo "  --make_arg argument             additional argument to be passed to make"
+	echo "  --skip_download                 $PACKAGE_NAME exists pre-downloaded at the source destination"
+	echo "  --skip_build                    $PACKAGE_NAME has already been built at the build destination"
+	echo "  --clean_source                  remove source directory after build"
+}
+
+
+# Parse command line options
+SKIP_DOWNLOAD=false
+SKIP_BUILD=false
+CLEAN_SOURCE=false
+while [ "$1" != "" ]; do
+	case $1 in
+		-h | --help )
+			usage
+			exit
+		;;
+		-d | --dest )
+			shift
+			DEST="$1"
+		;;
+		-s | --source )
+			shift
+			SOURCE_DIR="$1"
+		;;
+		-b | --build )
+			shift
+			BUILD_DIR="$1"
+		;;
+		--skip_download )
+			SKIP_DOWNLOAD=true
+		;;
+		--skip_build )
+			SKIP_BUILD=true
+		;;
+		--make_arg )
+			shift
+			MAKE_ARG="$1"
+		;;
+		--clean_source)
+			CLEAN_SOURCE=true
+		;;
+		* )
+			usage
+			exit 1
+		;;
+	esac
+	shift
+done
+
+if [ "$DEST" != "" ]; then
+	if [ -z "$SOURCE_DIR" ]; then
+		SOURCE_DIR="${DEST%/}/source/"
+	fi
+	if [ -z "$BUILD_DIR" ]; then
+		BUILD_DIR="${DEST%/}/build/"
+	fi
+fi
+
+if [ ! -d "$SOURCE_DIR" ]; then
+	echo "Invalid source destination directory: $SOURCE_DIR"
+	exit 2
+fi
+if [ ! -d "$BUILD_DIR" ]; then
+	echo "Invalid build destination directory: $BUILD_DIR"
+	exit 3
+fi
+
+# Download and unzip the package
+cd "$SOURCE_DIR"
+if [ $SKIP_DOWNLOAD = false ]; then
+	echo "Downloading $PACKAGE_NAME to $SOURCE_DIR"
+	wget "$DOWNLOAD_LINK" -O "$PACKAGE_DIR_NAME.tar.gz" || exit 11
+	echo "Extracting $PACKAGE_NAME"
+	mkdir "$PACKAGE_DIR_NAME"
+	tar -xzf "$PACKAGE_DIR_NAME.tar.gz" -C "$PACKAGE_DIR_NAME" --strip-components=1 || exit 12
+	rm "$PACKAGE_DIR_NAME.tar.gz"
+fi
+
+# Run package installation
+if [ $SKIP_BUILD = false ]; then
+	echo "Compiling $PACKAGE_NAME"
+	cd "$PACKAGE_DIR_NAME"
+	./configure --prefix="$BUILD_DIR" || exit 31
+	echo "Installing $PACKAGE_NAME"
+	make "$MAKE_ARG" || exit 32
+	make install "$MAKE_ARG" || exit 33
+fi
+
+# Clean up source directory if requested
+if [ $CLEAN_SOURCE = true ]; then
+	echo "Removing $PACKAGE_NAME source directory from $SOURCE_DIR"
+	cd "$SOURCE_DIR"
+	rm -rf "$PACKAGE_DIR_NAME"
+fi
+
+echo "$PACKAGE_NAME installed in $BUILD_DIR"

--- a/builders/v3.0.0/build_FFTW.sh
+++ b/builders/v3.0.0/build_FFTW.sh
@@ -1,0 +1,111 @@
+#!/bin/sh
+# Build script for FFTW
+
+# Set script parameters
+PACKAGE_NAME="FFTW"
+DOWNLOAD_LINK="http://www.fftw.org/fftw-3.3.9.tar.gz"
+PACKAGE_DIR_NAME="fftw-3.3.9"
+
+
+usage() {
+	echo "usage: $0 [-h] [-d destination] [-s destination] [-b destination] [--make_arg argument] [--skip_download, --skip_build] [--clean_source]"
+	echo "  -h, --help                      display this help message"
+	echo "  -d, --dest destination          set the destination directory (containing source and build directories)"
+	echo "  -s, --source destination        set the source destination directory"
+	echo "  -b, --build destination         set the build destination directory"
+	echo "  --make_arg argument             additional argument to be passed to make"
+	echo "  --skip_download                 $PACKAGE_NAME exists pre-downloaded at the source destination"
+	echo "  --skip_build                    $PACKAGE_NAME has already been built at the build destination"
+	echo "  --clean_source                  remove source directory after build"
+}
+
+# Parse command line options
+SKIP_DOWNLOAD=false
+SKIP_BUILD=false
+CLEAN_SOURCE=false
+while [ "$1" != "" ]; do
+	case $1 in
+		-h | --help )
+			usage
+			exit
+		;;
+		-d | --dest )
+			shift
+			DEST="$1"
+		;;
+		-s | --source )
+			shift
+			SOURCE_DIR="$1"
+		;;
+		-b | --build )
+			shift
+			BUILD_DIR="$1"
+		;;
+		--skip_download )
+			SKIP_DOWNLOAD=true
+		;;
+		--skip_build )
+			SKIP_BUILD=true
+		;;
+		--make_arg )
+			shift
+			MAKE_ARG="$1"
+		;;
+		--clean_source)
+			CLEAN_SOURCE=true
+		;;
+		* )
+			usage
+			exit 1
+		;;
+	esac
+	shift
+done
+
+if [ "$DEST" != "" ]; then
+	if [ -z "$SOURCE_DIR" ]; then
+		SOURCE_DIR="${DEST%/}/source/"
+	fi
+	if [ -z "$BUILD_DIR" ]; then
+		BUILD_DIR="${DEST%/}/build/"
+	fi
+fi
+
+if [ ! -d "$SOURCE_DIR" ]; then
+	echo "Invalid source destination directory: $SOURCE_DIR"
+	exit 2
+fi
+if [ ! -d "$BUILD_DIR" ]; then
+	echo "Invalid build destination directory: $BUILD_DIR"
+	exit 3
+fi
+
+# Download and unzip the package
+cd "$SOURCE_DIR"
+if [ $SKIP_DOWNLOAD = false ]; then
+	echo "Downloading $PACKAGE_NAME to $SOURCE_DIR"
+	wget "$DOWNLOAD_LINK" -O "$PACKAGE_DIR_NAME.tar.gz" || exit 11
+	echo "Extracting $PACKAGE_NAME"
+	mkdir "$PACKAGE_DIR_NAME"
+	tar -xzf "$PACKAGE_DIR_NAME.tar.gz" -C "$PACKAGE_DIR_NAME" --strip-components=1 || exit 12
+	rm "$PACKAGE_DIR_NAME.tar.gz"
+fi
+
+# Run package installation
+if [ $SKIP_BUILD = false ]; then
+	echo "Compiling $PACKAGE_NAME"
+	cd "$PACKAGE_DIR_NAME"
+	./configure --enable-shared --disable-fortran --prefix="$BUILD_DIR" || exit 31
+	echo "Installing $PACKAGE_NAME"
+	make "$MAKE_ARG" || exit 32
+	make install "$MAKE_ARG" || exit 33
+fi
+
+# Clean up source directory if requested
+if [ $CLEAN_SOURCE = true ]; then
+	echo "Removing $PACKAGE_NAME source directory from $SOURCE_DIR"
+	cd "$SOURCE_DIR"
+	rm -rf "$PACKAGE_DIR_NAME"
+fi
+
+echo "$PACKAGE_NAME installed in $BUILD_DIR"

--- a/builders/v3.0.0/build_GSL.sh
+++ b/builders/v3.0.0/build_GSL.sh
@@ -1,0 +1,111 @@
+#!/bin/sh
+# Build script for GSL
+
+# Set script parameters
+PACKAGE_NAME="GSL"
+DOWNLOAD_LINK="http://gnu.mirror.constant.com/gsl/gsl-2.6.tar.gz"
+PACKAGE_DIR_NAME="gsl-2.6"
+
+
+usage() {
+	echo "usage: $0 [-h] [-d destination] [-s destination] [-b destination] [--make_arg argument] [--skip_download, --skip_build] [--clean_source]"
+	echo "  -h, --help                      display this help message"
+	echo "  -d, --dest destination          set the destination directory (containing source and build directories)"
+	echo "  -s, --source destination        set the source destination directory"
+	echo "  -b, --build destination         set the build destination directory"
+	echo "  --make_arg argument             additional argument to be passed to make"
+	echo "  --skip_download                 $PACKAGE_NAME exists pre-downloaded at the source destination"
+	echo "  --skip_build                    $PACKAGE_NAME has already been built at the build destination"
+	echo "  --clean_source                  remove source directory after build"
+}
+
+# Parse command line options
+SKIP_DOWNLOAD=false
+SKIP_BUILD=false
+CLEAN_SOURCE=false
+while [ "$1" != "" ]; do
+	case $1 in
+		-h | --help )
+			usage
+			exit
+		;;
+		-d | --dest )
+			shift
+			DEST="$1"
+		;;
+		-s | --source )
+			shift
+			SOURCE_DIR="$1"
+		;;
+		-b | --build )
+			shift
+			BUILD_DIR="$1"
+		;;
+		--skip_download )
+			SKIP_DOWNLOAD=true
+		;;
+		--skip_build )
+			SKIP_BUILD=true
+		;;
+		--make_arg )
+			shift
+			MAKE_ARG="$1"
+		;;
+		--clean_source)
+			CLEAN_SOURCE=true
+		;;
+		* )
+			usage
+			exit 1
+		;;
+	esac
+	shift
+done
+
+if [ "$DEST" != "" ]; then
+	if [ -z "$SOURCE_DIR" ]; then
+		SOURCE_DIR="${DEST%/}/source/"
+	fi
+	if [ -z "$BUILD_DIR" ]; then
+		BUILD_DIR="${DEST%/}/build/"
+	fi
+fi
+
+if [ ! -d "$SOURCE_DIR" ]; then
+	echo "Invalid source destination directory: $SOURCE_DIR"
+	exit 2
+fi
+if [ ! -d "$BUILD_DIR" ]; then
+	echo "Invalid build destination directory: $BUILD_DIR"
+	exit 3
+fi
+
+# Download and unzip the package
+cd "$SOURCE_DIR"
+if [ $SKIP_DOWNLOAD = false ]; then
+	echo "Downloading $PACKAGE_NAME to $SOURCE_DIR"
+	wget "$DOWNLOAD_LINK" -O "$PACKAGE_DIR_NAME.tar.gz" || exit 11
+	echo "Extracting $PACKAGE_NAME"
+	mkdir "$PACKAGE_DIR_NAME"
+	tar -xzf "$PACKAGE_DIR_NAME.tar.gz" -C "$PACKAGE_DIR_NAME" --strip-components=1 || exit 12
+	rm "$PACKAGE_DIR_NAME.tar.gz"
+fi
+
+# Run package installation
+if [ $SKIP_BUILD = false ]; then
+	echo "Compiling $PACKAGE_NAME"
+	cd "$PACKAGE_DIR_NAME"
+	./configure CFLAGS=-m64 --with-pic --enable-shared --prefix="$BUILD_DIR" || exit 31
+	echo "Installing $PACKAGE_NAME"
+	make "$MAKE_ARG" || exit 32
+	make install "$MAKE_ARG" || exit 33
+fi
+
+# Clean up source directory if requested
+if [ $CLEAN_SOURCE = true ]; then
+	echo "Removing $PACKAGE_NAME source directory from $SOURCE_DIR"
+	cd "$SOURCE_DIR"
+	rm -rf "$PACKAGE_DIR_NAME"
+fi
+
+echo "$PACKAGE_NAME installed in $BUILD_DIR"

--- a/builders/v3.0.0/build_ROOT6.sh
+++ b/builders/v3.0.0/build_ROOT6.sh
@@ -1,0 +1,134 @@
+#!/bin/sh
+# Build script for ROOT6
+
+# Set script parameters
+PACKAGE_NAME="ROOT6"
+DOWNLOAD_LINK="https://root.cern/download/root_v6.22.06.source.tar.gz"
+PACKAGE_DIR_NAME="root-6.22.06"
+
+
+usage() {
+	echo "usage: $0 [-h] [-d destination] [-s destination] [-b destination] [--deps directory] [--make_arg argument] [--skip_download, --skip_build] [--clean_source]"
+	echo "  -h, --help                      display this help message"
+	echo "  -d, --dest destination          set the destination directory (containing source and build directories)"
+	echo "  -s, --source destination        set the source destination directory"
+	echo "  -b, --build destination         set the build destination directory"
+	echo "  --deps directory                set the dependency build directory"
+	echo "  --make_arg argument             additional argument to be passed to make"
+	echo "  --skip_download                 $PACKAGE_NAME exists pre-downloaded at the source destination"
+	echo "  --skip_build                    $PACKAGE_NAME has already been built at the build destination"
+	echo "  --clean_source                  remove source directory after build"
+}
+
+# Parse command line options
+SKIP_DOWNLOAD=false
+SKIP_BUILD=false
+CLEAN_SOURCE=false
+while [ "$1" != "" ]; do
+	case $1 in
+		-h | --help )
+			usage
+			exit
+		;;
+		-d | --dest )
+			shift
+			DEST="$1"
+		;;
+		-s | --source )
+			shift
+			SOURCE_DIR="$1"
+		;;
+		-b | --build )
+			shift
+			BUILD_DIR="$1"
+		;;
+		--deps )
+			shift
+			DEPS_BUILD_DIR="$1"
+		;;
+		--skip_download )
+			SKIP_DOWNLOAD=true
+		;;
+		--skip_build )
+			SKIP_BUILD=true
+		;;
+		--make_arg )
+			shift
+			MAKE_ARG="$1"
+		;;
+		--clean_source)
+			CLEAN_SOURCE=true
+		;;
+		* )
+			usage
+			exit 1
+		;;
+	esac
+	shift
+done
+
+if [ "$DEST" != "" ]; then
+	if [ -z "$SOURCE_DIR" ]; then
+		SOURCE_DIR="${DEST%/}/source/"
+	fi
+	if [ -z "$BUILD_DIR" ]; then
+		BUILD_DIR="${DEST%/}/build/"
+	fi
+fi
+
+if [ -z "$DEPS_BUILD_DIR" ]; then
+	DEPS_BUILD_DIR="$BUILD_DIR"
+fi
+
+if [ ! -d "$SOURCE_DIR" ]; then
+	echo "Invalid source destination directory: $SOURCE_DIR"
+	exit 2
+fi
+if [ ! -d "$BUILD_DIR" ]; then
+	echo "Invalid build destination directory: $BUILD_DIR"
+	exit 3
+fi
+if [ ! -d "$DEPS_BUILD_DIR" ]; then
+	echo "Invalid dependency build directory: $DEPS_BUILD_DIR"
+	exit 4
+fi
+
+
+# Download and unzip the package
+cd "$SOURCE_DIR"
+if [ $SKIP_DOWNLOAD = false ]; then
+	echo "Downloading $PACKAGE_NAME to $SOURCE_DIR"
+	wget "$DOWNLOAD_LINK" -O "$PACKAGE_DIR_NAME.tar.gz" || exit 11
+	echo "Extracting $PACKAGE_NAME"
+	mkdir "$PACKAGE_DIR_NAME"
+	tar -xzf "$PACKAGE_DIR_NAME.tar.gz" -C "$PACKAGE_DIR_NAME" --strip-components=1 || exit 12
+	rm "$PACKAGE_DIR_NAME.tar.gz"
+fi
+
+# Set required environment variables
+if [ $SKIP_BUILD = false ]; then
+	export ARA_DEPS_INSTALL_DIR="${DEPS_BUILD_DIR%/}"
+	export LD_LIBRARY_PATH="$ARA_DEPS_INSTALL_DIR/lib:$LD_LIBRARY_PATH"
+	export DYLD_LIBRARY_PATH="$ARA_DEPS_INSTALL_DIR/lib:$DYLD_LIBRARY_PATH"
+	export PATH="$ARA_DEPS_INSTALL_DIR/bin:$PATH"
+	export CMAKE_PREFIX_PATH="$ARA_DEPS_INSTALL_DIR"
+fi
+
+# Run package installation
+if [ $SKIP_BUILD = false ]; then
+	echo "Compiling $PACKAGE_NAME"
+	cd "$BUILD_DIR"
+	cmake -Dminuit2:bool=true -DPYTHON_EXECUTABLE="${ARA_DEPS_INSTALL_DIR}/bin/python" "${SOURCE_DIR%/}/$PACKAGE_DIR_NAME" || exit 31
+	# cmake -Dminuit2:bool=true -DPYTHON_EXECUTABLE="${ARA_DEPS_INSTALL_DIR}/miniconda/bin/python" "${SOURCE_DIR%/}/$PACKAGE_DIR_NAME" || exit 31
+	echo "Installing $PACKAGE_NAME"
+	make "$MAKE_ARG" || exit 32
+fi
+
+# Clean up source directory if requested
+if [ $CLEAN_SOURCE = true ]; then
+	echo "Removing $PACKAGE_NAME source directory from $SOURCE_DIR"
+	cd "$SOURCE_DIR"
+	rm -rf "$PACKAGE_DIR_NAME"
+fi
+
+echo "$PACKAGE_NAME installed in $BUILD_DIR"

--- a/builders/v3.0.0/build_SQLite.sh
+++ b/builders/v3.0.0/build_SQLite.sh
@@ -1,0 +1,111 @@
+#!/bin/sh
+# Build script for SQLite
+
+# Set script parameters
+PACKAGE_NAME="SQLite"
+DOWNLOAD_LINK="https://www.sqlite.org/2021/sqlite-autoconf-3340100.tar.gz"
+PACKAGE_DIR_NAME="sqlite-autoconf-3340100"
+
+
+usage() {
+	echo "usage: $0 [-h] [-d destination] [-s destination] [-b destination] [--make_arg argument] [--skip_download, --skip_build] [--clean_source]"
+	echo "  -h, --help                      display this help message"
+	echo "  -d, --dest destination          set the destination directory (containing source and build directories)"
+	echo "  -s, --source destination        set the source destination directory"
+	echo "  -b, --build destination         set the build destination directory"
+	echo "  --make_arg argument             additional argument to be passed to make"
+	echo "  --skip_download                 $PACKAGE_NAME exists pre-downloaded at the source destination"
+	echo "  --skip_build                    $PACKAGE_NAME has already been built at the build destination"
+	echo "  --clean_source                  remove source directory after build"
+}
+
+# Parse command line options
+SKIP_DOWNLOAD=false
+SKIP_BUILD=false
+CLEAN_SOURCE=false
+while [ "$1" != "" ]; do
+	case $1 in
+		-h | --help )
+			usage
+			exit
+		;;
+		-d | --dest )
+			shift
+			DEST="$1"
+		;;
+		-s | --source )
+			shift
+			SOURCE_DIR="$1"
+		;;
+		-b | --build )
+			shift
+			BUILD_DIR="$1"
+		;;
+		--skip_download )
+			SKIP_DOWNLOAD=true
+		;;
+		--skip_build )
+			SKIP_BUILD=true
+		;;
+		--make_arg )
+			shift
+			MAKE_ARG="$1"
+		;;
+		--clean_source)
+			CLEAN_SOURCE=true
+		;;
+		* )
+			usage
+			exit 1
+		;;
+	esac
+	shift
+done
+
+if [ "$DEST" != "" ]; then
+	if [ -z "$SOURCE_DIR" ]; then
+		SOURCE_DIR="${DEST%/}/source/"
+	fi
+	if [ -z "$BUILD_DIR" ]; then
+		BUILD_DIR="${DEST%/}/build/"
+	fi
+fi
+
+if [ ! -d "$SOURCE_DIR" ]; then
+	echo "Invalid source destination directory: $SOURCE_DIR"
+	exit 2
+fi
+if [ ! -d "$BUILD_DIR" ]; then
+	echo "Invalid build destination directory: $BUILD_DIR"
+	exit 3
+fi
+
+# Download and unzip the package
+cd "$SOURCE_DIR"
+if [ $SKIP_DOWNLOAD = false ]; then
+	echo "Downloading $PACKAGE_NAME to $SOURCE_DIR"
+	wget "$DOWNLOAD_LINK" -O "$PACKAGE_DIR_NAME.tar.gz" || exit 11
+	echo "Extracting $PACKAGE_NAME"
+	mkdir "$PACKAGE_DIR_NAME"
+	tar -xzf "$PACKAGE_DIR_NAME.tar.gz" -C "$PACKAGE_DIR_NAME" --strip-components=1 || exit 12
+	rm "$PACKAGE_DIR_NAME.tar.gz"
+fi
+
+# Run package installation
+if [ $SKIP_BUILD = false ]; then
+	echo "Compiling $PACKAGE_NAME"
+	cd "$PACKAGE_DIR_NAME"
+	./configure --enable-shared --prefix="$BUILD_DIR" || exit 31
+	echo "Installing $PACKAGE_NAME"
+	make "$MAKE_ARG" || exit 32
+	make install "$MAKE_ARG" || exit 33
+fi
+
+# Clean up source directory if requested
+if [ $CLEAN_SOURCE = true ]; then
+	echo "Removing $PACKAGE_NAME source directory from $SOURCE_DIR"
+	cd "$SOURCE_DIR"
+	rm -rf "$PACKAGE_DIR_NAME"
+fi
+
+echo "$PACKAGE_NAME installed in $BUILD_DIR"

--- a/builders/v3.0.0/build_boost.sh
+++ b/builders/v3.0.0/build_boost.sh
@@ -1,0 +1,132 @@
+#!/bin/sh
+# Build script for boost
+
+# Set script parameters
+PACKAGE_NAME="boost"
+DOWNLOAD_LINK="https://sourceforge.net/projects/boost/files/boost/1.75.0/boost_1_75_0.tar.gz"
+PACKAGE_DIR_NAME="boost_1_75_0"
+
+
+usage() {
+	echo "usage: $0 [-h] [-d destination] [-s destination] [-b destination] [--make_arg argument] [--skip_download, --skip_build] [--clean_source]"
+	echo "  -h, --help                      display this help message"
+	echo "  -d, --dest destination          set the destination directory (containing source and build directories)"
+	echo "  -s, --source destination        set the source destination directory"
+	echo "  -b, --build destination         set the build destination directory"
+	echo "  --make_arg argument             additional argument to be passed to make"
+	echo "  --skip_download                 $PACKAGE_NAME exists pre-downloaded at the source destination"
+	echo "  --skip_build                    $PACKAGE_NAME has already been built at the build destination"
+	echo "  --clean_source                  remove source directory after build"
+}
+
+
+# Parse command line options
+SKIP_DOWNLOAD=false
+SKIP_BUILD=false
+CLEAN_SOURCE=false
+while [ "$1" != "" ]; do
+	case $1 in
+		-h | --help )
+			usage
+			exit
+		;;
+		-d | --dest )
+			shift
+			DEST="$1"
+		;;
+		-s | --source )
+			shift
+			SOURCE_DIR="$1"
+		;;
+		-b | --build )
+			shift
+			BUILD_DIR="$1"
+		;;
+		--skip_download )
+			SKIP_DOWNLOAD=true
+		;;
+		--skip_build )
+			SKIP_BUILD=true
+		;;
+		--make_arg )
+			shift
+			MAKE_ARG="$1"
+		;;
+		--clean_source)
+			CLEAN_SOURCE=true
+		;;
+		* )
+			usage
+			exit 1
+		;;
+	esac
+	shift
+done
+
+if [ "$DEST" != "" ]; then
+	if [ -z "$SOURCE_DIR" ]; then
+		SOURCE_DIR="${DEST%/}/source/"
+	fi
+	if [ -z "$BUILD_DIR" ]; then
+		BUILD_DIR="${DEST%/}/build/"
+	fi
+fi
+
+if [ ! -d "$SOURCE_DIR" ]; then
+	echo "Invalid source destination directory: $SOURCE_DIR"
+	exit 2
+fi
+if [ ! -d "$BUILD_DIR" ]; then
+	echo "Invalid build destination directory: $BUILD_DIR"
+	exit 3
+fi
+
+# Download and unzip the package
+cd "$SOURCE_DIR"
+if [ $SKIP_DOWNLOAD = false ]; then
+	echo "Downloading $PACKAGE_NAME to $SOURCE_DIR"
+	wget "$DOWNLOAD_LINK" -O "$PACKAGE_DIR_NAME.tar.gz" || exit 11
+	echo "Extracting $PACKAGE_NAME"
+	mkdir "$PACKAGE_DIR_NAME"
+	tar -xzf "$PACKAGE_DIR_NAME.tar.gz" -C "$PACKAGE_DIR_NAME" --strip-components=1 || exit 12
+	rm "$PACKAGE_DIR_NAME.tar.gz"
+fi
+
+# Run package installation
+if [ $SKIP_BUILD = false ]; then
+	echo "Compiling $PACKAGE_NAME"
+	cd "$PACKAGE_DIR_NAME"
+	./bootstrap.sh --without-libraries=python --prefix="${BUILD_DIR%/}" || exit 31
+	echo "Installing $PACKAGE_NAME"
+	
+	# It is important in boost versions > 1.73 to check for make args
+	# and to manually specify the number of cores to use (to 1)
+	# in the case that the the user does not specify for us.
+	# This is becuase in boost > 1.73, the default number of
+	# jobs/threads used in the compile is set to the number of available cpu threads.
+	# But the Boost manual warns us that "There are circumstances when that default can be larger 
+	# than the allocated cpu resources, for instance in some virtualized container installs."
+	# Because the buildbost for cvmfs is done in a container, we will run into a 
+	# problem where the builder will try and use cores that are allocated outside
+	# the container. So we must protect against this by having a "fall-back"
+	# option where we allow it access to only 1 core, unless the user specifies otherwise.
+
+	echo "make arg is $MAKE_ARG"
+
+	if [ -z "$MAKE_ARG" ]
+	then
+		./b2 -j 1
+	else
+		./b2 "$MAKE_ARG"		
+	fi
+	./b2 install
+fi
+
+# Clean up source directory if requested
+if [ $CLEAN_SOURCE = true ]; then
+	echo "Removing $PACKAGE_NAME source directory from $SOURCE_DIR"
+	cd "$SOURCE_DIR"
+	rm -rf "$PACKAGE_DIR_NAME"
+fi
+
+echo "$PACKAGE_NAME installed in $BUILD_DIR"

--- a/builders/v3.0.0/build_libRootFftwWrapper.sh
+++ b/builders/v3.0.0/build_libRootFftwWrapper.sh
@@ -1,0 +1,156 @@
+#!/bin/sh
+# Build script for libRootFftwWrapper
+
+# Set script parameters
+PACKAGE_NAME="libRootFftwWrapper"
+DOWNLOAD_LINK="https://github.com/nichol77/libRootFftwWrapper/archive/24c667cbaf88a44707d1c47496cfd781d68df593.tar.gz"
+PACKAGE_DIR_NAME="libRootFftwWrapper"
+
+
+usage() {
+	echo "usage: $0 [-h] [-d destination] [-s destination] [-b destination] [-r directory] [--deps directory] [--make_arg argument] [--skip_download, --skip_build] [--clean_source]"
+	echo "  -h, --help                      display this help message"
+	echo "  -d, --dest destination          set the destination directory (containing source and build directories)"
+	echo "  -s, --source destination        set the source destination directory"
+	echo "  -b, --build destination         set the build destination directory"
+	echo "  -r, --root directory            set the root build directory"
+	echo "  --deps directory                set the dependency build directory"
+	echo "  --make_arg argument             additional argument to be passed to make"
+	echo "  --skip_download                 $PACKAGE_NAME exists pre-downloaded at the source destination"
+	echo "  --skip_build                    $PACKAGE_NAME has already been built at the build destination"
+	echo "  --clean_source                  remove source directory after build"
+}
+
+# Parse command line options
+SKIP_DOWNLOAD=false
+SKIP_BUILD=false
+CLEAN_SOURCE=false
+while [ "$1" != "" ]; do
+	case $1 in
+		-h | --help )
+			usage
+			exit
+		;;
+		-d | --dest )
+			shift
+			DEST="$1"
+		;;
+		-s | --source )
+			shift
+			SOURCE_DIR="$1"
+		;;
+		-b | --build )
+			shift
+			BUILD_DIR="$1"
+		;;
+		-r | --root )
+			shift
+			ROOT_BUILD_DIR="$1"
+		;;
+		--deps )
+			shift
+			DEPS_BUILD_DIR="$1"
+		;;
+		--skip_download )
+			SKIP_DOWNLOAD=true
+		;;
+		--skip_build )
+			SKIP_BUILD=true
+		;;
+		--make_arg )
+			shift
+			MAKE_ARG="$1"
+		;;
+		--clean_source)
+			CLEAN_SOURCE=true
+		;;
+		* )
+			usage
+			exit 1
+		;;
+	esac
+	shift
+done
+
+if [ "$DEST" != "" ]; then
+	if [ -z "$SOURCE_DIR" ]; then
+		SOURCE_DIR="${DEST%/}/source/"
+	fi
+	if [ -z "$BUILD_DIR" ]; then
+		BUILD_DIR="${DEST%/}/build/"
+	fi
+fi
+
+if [ -z "$DEPS_BUILD_DIR" ]; then
+	DEPS_BUILD_DIR="$BUILD_DIR"
+fi
+
+if [ -z "$ROOT_BUILD_DIR" ]; then
+	ROOT_BUILD_DIR="$BUILD_DIR"
+fi
+
+if [ ! -d "$SOURCE_DIR" ]; then
+	echo "Invalid source destination directory: $SOURCE_DIR"
+	exit 2
+fi
+if [ ! -d "$BUILD_DIR" ]; then
+	echo "Invalid build destination directory: $BUILD_DIR"
+	exit 3
+fi
+if [ ! -d "$DEPS_BUILD_DIR" ]; then
+	echo "Invalid dependency build directory: $DEPS_BUILD_DIR"
+	exit 4
+fi
+if [ ! -d "$ROOT_BUILD_DIR" ]; then
+	echo "Invalid root build directory: $ROOT_BUILD_DIR"
+	exit 5
+fi
+
+
+# Download and unzip the package
+cd "$SOURCE_DIR"
+if [ $SKIP_DOWNLOAD = false ]; then
+	echo "Downloading $PACKAGE_NAME to $SOURCE_DIR"
+	wget "$DOWNLOAD_LINK" -O "$PACKAGE_DIR_NAME.tar.gz" || exit 11
+	echo "Extracting $PACKAGE_NAME"
+	mkdir "$PACKAGE_DIR_NAME"
+	tar -xzf "$PACKAGE_DIR_NAME.tar.gz" -C "$PACKAGE_DIR_NAME" --strip-components=1 || exit 12
+	rm "$PACKAGE_DIR_NAME.tar.gz"
+fi
+
+# Set required environment variables
+if [ $SKIP_BUILD = false ]; then
+	export ARA_UTIL_INSTALL_DIR="${DEPS_BUILD_DIR%/}"
+	export ARA_DEPS_INSTALL_DIR="${DEPS_BUILD_DIR%/}"
+	export LD_LIBRARY_PATH="$ARA_DEPS_INSTALL_DIR/lib:$LD_LIBRARY_PATH"
+	export DYLD_LIBRARY_PATH="$ARA_DEPS_INSTALL_DIR/lib:$DYLD_LIBRARY_PATH"
+	export PATH="$ARA_DEPS_INSTALL_DIR/bin:$PATH"
+	. "${ROOT_BUILD_DIR%/}"/bin/thisroot.sh || exit 21
+	export SQLITE_ROOT="$ARA_DEPS_INSTALL_DIR"
+	export GSL_ROOT="$ARA_DEPS_INSTALL_DIR"
+	export FFTWSYS="$ARA_DEPS_INSTALL_DIR"
+	export CMAKE_PREFIX_PATH="$ARA_DEPS_INSTALL_DIR"
+fi
+
+# Run package installation
+if [ $SKIP_BUILD = false ]; then
+	echo "Compiling $PACKAGE_NAME"
+	cd "$PACKAGE_DIR_NAME"
+	sed -i 's:^find_package(FFTW REQUIRED):#find_package(FFTW REQUIRED)\
+set(FFTW_LIBRARIES "$ENV{FFTWSYS}/lib/libfftw3.so.3.6.9")\
+set(FFTW_INCLUDES "$ENV{FFTWSYS}/include"):' CMakeLists.txt
+	sed -i 's:@ccmake:@cmake:' Makefile
+	make configure "$MAKE_ARG" || exit 31
+	echo "Installing $PACKAGE_NAME"
+	make "$MAKE_ARG" || exit 32
+	make install "$MAKE_ARG" || exit 33
+fi
+
+# Clean up source directory if requested
+if [ $CLEAN_SOURCE = true ]; then
+	echo "Removing $PACKAGE_NAME source directory from $SOURCE_DIR"
+	cd "$SOURCE_DIR"
+	rm -rf "$PACKAGE_DIR_NAME"
+fi
+
+echo "$PACKAGE_NAME installed in $BUILD_DIR"

--- a/builders/v3.0.0/build_libnuphase.sh
+++ b/builders/v3.0.0/build_libnuphase.sh
@@ -1,0 +1,155 @@
+#!/bin/sh
+# Build script for libnuphase
+
+# Set script parameters
+PACKAGE_NAME="libnuphase"
+DOWNLOAD_LINK="https://github.com/vPhase/libnuphase/archive/23d66155a7d908738a1390749fae822be1bf0fcb.tar.gz"
+PACKAGE_DIR_NAME="libnuphase"
+
+usage() {
+	echo "usage: $0 [-h] [-d destination] [-s destination] [-b destination] [-r directory] [--deps directory] [--skip_download, --skip_build] [--clean_source]"
+	echo "  -h, --help                      display this help message"
+	echo "  -d, --dest destination          set the destination directory (containing source and build directories)"
+	echo "  -s, --source destination        set the source destination directory"
+	echo "  -b, --build destination         set the build destination directory"
+	echo "  -r, --root directory            set the root build directory"
+	echo "  --deps directory                set the dependency build directory"
+	echo "  --skip_download                 $PACKAGE_NAME exists pre-downloaded at the source destination"
+	echo "  --skip_build                    $PACKAGE_NAME has already been built at the build destination"
+	echo "  --clean_source                  remove source directory after build"
+}
+
+# Parse command line options
+SKIP_DOWNLOAD=false
+SKIP_BUILD=false
+CLEAN_SOURCE=false
+while [ "$1" != "" ]; do
+	case $1 in
+		-h | --help )
+			usage
+			exit
+		;;
+		-d | --dest )
+			shift
+			DEST="$1"
+		;;
+		-s | --source )
+			shift
+			SOURCE_DIR="$1"
+		;;
+		-b | --build )
+			shift
+			BUILD_DIR="$1"
+		;;
+		-r | --root )
+			shift
+			ROOT_BUILD_DIR="$1"
+		;;
+		--deps )
+			shift
+			DEPS_BUILD_DIR="$1"
+		;;
+		--skip_download )
+			SKIP_DOWNLOAD=true
+		;;
+		--skip_build )
+			SKIP_BUILD=true
+		;;
+		--clean_source)
+			CLEAN_SOURCE=true
+		;;
+		* )
+			usage
+			exit 1
+		;;
+	esac
+	shift
+done
+
+if [ "$DEST" != "" ]; then
+	if [ -z "$SOURCE_DIR" ]; then
+		SOURCE_DIR="${DEST%/}/source/"
+	fi
+	if [ -z "$BUILD_DIR" ]; then
+		BUILD_DIR="${DEST%/}/build/"
+	fi
+fi
+
+if [ -z "$DEPS_BUILD_DIR" ]; then
+	DEPS_BUILD_DIR="$BUILD_DIR"
+fi
+
+if [ -z "$ROOT_BUILD_DIR" ]; then
+	ROOT_BUILD_DIR="$BUILD_DIR"
+fi
+
+if [ ! -d "$SOURCE_DIR" ]; then
+	echo "Invalid source destination directory: $SOURCE_DIR"
+	exit 2
+fi
+if [ ! -d "$BUILD_DIR" ]; then
+	echo "Invalid build destination directory: $BUILD_DIR"
+	exit 3
+fi
+if [ ! -d "$DEPS_BUILD_DIR" ]; then
+	echo "Invalid dependency build directory: $DEPS_BUILD_DIR"
+	exit 4
+fi
+if [ ! -d "$ROOT_BUILD_DIR" ]; then
+	echo "Invalid root build directory: $ROOT_BUILD_DIR"
+	exit 5
+fi
+
+
+# Download and unzip the package
+cd "$SOURCE_DIR"
+if [ $SKIP_DOWNLOAD = false ]; then
+	echo "Downloading $PACKAGE_NAME to $SOURCE_DIR"
+	wget "$DOWNLOAD_LINK" -O "$PACKAGE_DIR_NAME.tar.gz" || exit 11
+	echo "Extracting $PACKAGE_NAME"
+	mkdir "$PACKAGE_DIR_NAME"
+	tar -xzf "$PACKAGE_DIR_NAME.tar.gz" -C "$PACKAGE_DIR_NAME" --strip-components=1 || exit 12
+	rm "$PACKAGE_DIR_NAME.tar.gz"
+fi
+
+# Set required environment variables
+if [ $SKIP_BUILD = false ]; then
+	export ARA_UTIL_INSTALL_DIR="${BUILD_DIR%/}"
+	export ARA_DEPS_INSTALL_DIR="${DEPS_BUILD_DIR%/}"
+	export ARA_ROOT_DIR="${SOURCE_DIR%/}/$PACKAGE_DIR_NAME"
+	export LD_LIBRARY_PATH="$ARA_DEPS_INSTALL_DIR/lib:$LD_LIBRARY_PATH"
+	export DYLD_LIBRARY_PATH="$ARA_DEPS_INSTALL_DIR/lib:$DYLD_LIBRARY_PATH"
+	export PATH="$ARA_DEPS_INSTALL_DIR/bin:$PATH"
+	. "${ROOT_BUILD_DIR%/}"/bin/thisroot.sh || exit 21
+	export SQLITE_ROOT="$ARA_DEPS_INSTALL_DIR"
+	export GSL_ROOT="$ARA_DEPS_INSTALL_DIR"
+	export FFTWSYS="$ARA_DEPS_INSTALL_DIR"
+	export CMAKE_PREFIX_PATH="$ARA_DEPS_INSTALL_DIR"
+fi
+
+# Run package installation
+if [ $SKIP_BUILD = false ]; then
+	echo "Compiling $PACKAGE_NAME"
+	cd "$PACKAGE_DIR_NAME"
+
+	# turn curl support off for installation on cluster for offline applications
+	sed -i 's:ENABLE_CURL=1:ENABLE_CURL=0:' Makefile
+
+	# change the PREFIX for installation (because libnuphase doesn't support proper --prefix_
+	sed -i 's:PREFIX=/nuphase:PREFIX=$(ARA_UTIL_INSTALL_DIR):' Makefile
+
+	# compile
+	make
+
+	# install
+	make install
+fi
+
+# Clean up source directory if requested
+if [ $CLEAN_SOURCE = true ]; then
+	echo "Removing $PACKAGE_NAME source directory from $SOURCE_DIR"
+	cd "$SOURCE_DIR"
+	rm -rf "$PACKAGE_DIR_NAME"
+fi
+
+echo "$PACKAGE_NAME installed in $BUILD_DIR"

--- a/builders/v3.0.0/build_nuphaseroot.sh
+++ b/builders/v3.0.0/build_nuphaseroot.sh
@@ -1,0 +1,151 @@
+#!/bin/sh
+# Build script for nuphaseroot
+
+# Set script parameters
+PACKAGE_NAME="nuphaseroot"
+DOWNLOAD_LINK="https://github.com/vPhase/nuphaseroot/archive/fa1489948659eef7e575dbda9e27c41896a3150f.tar.gz"
+PACKAGE_DIR_NAME="nuphaseroot"
+
+usage() {
+	echo "usage: $0 [-h] [-d destination] [-s destination] [-b destination] [-r directory] [--deps directory] [--skip_download, --skip_build] [--clean_source]"
+	echo "  -h, --help                      display this help message"
+	echo "  -d, --dest destination          set the destination directory (containing source and build directories)"
+	echo "  -s, --source destination        set the source destination directory"
+	echo "  -b, --build destination         set the build destination directory"
+	echo "  -r, --root directory            set the root build directory"
+	echo "  --deps directory                set the dependency build directory"
+	echo "  --skip_download                 $PACKAGE_NAME exists pre-downloaded at the source destination"
+	echo "  --skip_build                    $PACKAGE_NAME has already been built at the build destination"
+	echo "  --clean_source                  remove source directory after build"
+}
+
+# Parse command line options
+SKIP_DOWNLOAD=false
+SKIP_BUILD=false
+CLEAN_SOURCE=false
+while [ "$1" != "" ]; do
+	case $1 in
+		-h | --help )
+			usage
+			exit
+		;;
+		-d | --dest )
+			shift
+			DEST="$1"
+		;;
+		-s | --source )
+			shift
+			SOURCE_DIR="$1"
+		;;
+		-b | --build )
+			shift
+			BUILD_DIR="$1"
+		;;
+		-r | --root )
+			shift
+			ROOT_BUILD_DIR="$1"
+		;;
+		--deps )
+			shift
+			DEPS_BUILD_DIR="$1"
+		;;
+		--skip_download )
+			SKIP_DOWNLOAD=true
+		;;
+		--skip_build )
+			SKIP_BUILD=true
+		;;
+		--clean_source)
+			CLEAN_SOURCE=true
+		;;
+		* )
+			usage
+			exit 1
+		;;
+	esac
+	shift
+done
+
+if [ "$DEST" != "" ]; then
+	if [ -z "$SOURCE_DIR" ]; then
+		SOURCE_DIR="${DEST%/}/source/"
+	fi
+	if [ -z "$BUILD_DIR" ]; then
+		BUILD_DIR="${DEST%/}/build/"
+	fi
+fi
+
+if [ -z "$DEPS_BUILD_DIR" ]; then
+	DEPS_BUILD_DIR="$BUILD_DIR"
+fi
+
+if [ -z "$ROOT_BUILD_DIR" ]; then
+	ROOT_BUILD_DIR="$BUILD_DIR"
+fi
+
+if [ ! -d "$SOURCE_DIR" ]; then
+	echo "Invalid source destination directory: $SOURCE_DIR"
+	exit 2
+fi
+if [ ! -d "$BUILD_DIR" ]; then
+	echo "Invalid build destination directory: $BUILD_DIR"
+	exit 3
+fi
+if [ ! -d "$DEPS_BUILD_DIR" ]; then
+	echo "Invalid dependency build directory: $DEPS_BUILD_DIR"
+	exit 4
+fi
+if [ ! -d "$ROOT_BUILD_DIR" ]; then
+	echo "Invalid root build directory: $ROOT_BUILD_DIR"
+	exit 5
+fi
+
+
+# Download and unzip the package
+cd "$SOURCE_DIR"
+if [ $SKIP_DOWNLOAD = false ]; then
+	echo "Downloading $PACKAGE_NAME to $SOURCE_DIR"
+	wget "$DOWNLOAD_LINK" -O "$PACKAGE_DIR_NAME.tar.gz" || exit 11
+	echo "Extracting $PACKAGE_NAME"
+	mkdir "$PACKAGE_DIR_NAME"
+	tar -xzf "$PACKAGE_DIR_NAME.tar.gz" -C "$PACKAGE_DIR_NAME" --strip-components=1 || exit 12
+	rm "$PACKAGE_DIR_NAME.tar.gz"
+fi
+
+# Set required environment variables
+if [ $SKIP_BUILD = false ]; then
+	export ARA_UTIL_INSTALL_DIR="${BUILD_DIR%/}"
+	export ARA_DEPS_INSTALL_DIR="${DEPS_BUILD_DIR%/}"
+	export ARA_ROOT_DIR="${SOURCE_DIR%/}/$PACKAGE_DIR_NAME"
+	export LD_LIBRARY_PATH="$ARA_DEPS_INSTALL_DIR/lib:$LD_LIBRARY_PATH"
+	export DYLD_LIBRARY_PATH="$ARA_DEPS_INSTALL_DIR/lib:$DYLD_LIBRARY_PATH"
+	export PATH="$ARA_DEPS_INSTALL_DIR/bin:$PATH"
+	. "${ROOT_BUILD_DIR%/}"/bin/thisroot.sh || exit 21
+	export SQLITE_ROOT="$ARA_DEPS_INSTALL_DIR"
+	export GSL_ROOT="$ARA_DEPS_INSTALL_DIR"
+	export FFTWSYS="$ARA_DEPS_INSTALL_DIR"
+	export CMAKE_PREFIX_PATH="$ARA_DEPS_INSTALL_DIR"
+	export NUPHASE_INSTALL_DIR="$ARA_UTIL_INSTALL_DIR"
+fi
+
+# Run package installation
+if [ $SKIP_BUILD = false ]; then
+	echo "Compiling $PACKAGE_NAME"
+	cd "$PACKAGE_DIR_NAME"
+	
+	# enable on libnuphase support and set libnuphase_path explicitly
+	cmake -DLIBNUPHASE_SUPPORT=ON -DLIBNUPHASE_PATH="$ARA_UTIL_INSTALL_DIR/lib"
+	
+	make
+	make install
+
+fi
+
+# Clean up source directory if requested
+if [ $CLEAN_SOURCE = true ]; then
+	echo "Removing $PACKAGE_NAME source directory from $SOURCE_DIR"
+	cd "$SOURCE_DIR"
+	rm -rf "$PACKAGE_DIR_NAME"
+fi
+
+echo "$PACKAGE_NAME installed in $BUILD_DIR"

--- a/builders/v3.0.0/build_python3.sh
+++ b/builders/v3.0.0/build_python3.sh
@@ -1,0 +1,124 @@
+#!/bin/sh
+# Build script for python3
+
+# Set script parameters
+PACKAGE_NAME="python3"
+DOWNLOAD_LINK="https://www.python.org/ftp/python/3.8.5/Python-3.8.5.tgz"
+PACKAGE_DIR_NAME="py3.8.5"
+
+
+usage() {
+	echo "usage: $0 [-h] [-d destination] [-s destination] [-b destination] [--make_arg argument] [--skip_download, --skip_build] [--clean_source]"
+	echo "  -h, --help                      display this help message"
+	echo "  -d, --dest destination          set the destination directory (containing source and build directories)"
+	echo "  -s, --source destination        set the source destination directory"
+	echo "  -b, --build destination         set the build destination directory"
+	echo "  --make_arg argument             additional argument to be passed to make"
+	echo "  --skip_download                 $PACKAGE_NAME exists pre-downloaded at the source destination"
+	echo "  --skip_build                    $PACKAGE_NAME has already been built at the build destination"
+	echo "  --clean_source                  remove source directory after build"
+}
+
+# Parse command line options
+SKIP_DOWNLOAD=false
+SKIP_BUILD=false
+CLEAN_SOURCE=false
+while [ "$1" != "" ]; do
+	case $1 in
+		-h | --help )
+			usage
+			exit
+		;;
+		-d | --dest )
+			shift
+			DEST="$1"
+		;;
+		-s | --source )
+			shift
+			SOURCE_DIR="$1"
+		;;
+		-b | --build )
+			shift
+			BUILD_DIR="$1"
+		;;
+		--skip_download )
+			SKIP_DOWNLOAD=true
+		;;
+		--skip_build )
+			SKIP_BUILD=true
+		;;
+		--make_arg )
+			shift
+			MAKE_ARG="$1"
+		;;
+		--clean_source)
+			CLEAN_SOURCE=true
+		;;
+		* )
+			usage
+			exit 1
+		;;
+	esac
+	shift
+done
+
+if [ "$DEST" != "" ]; then
+	if [ -z "$SOURCE_DIR" ]; then
+		SOURCE_DIR="${DEST%/}/source/"
+	fi
+	if [ -z "$BUILD_DIR" ]; then
+		BUILD_DIR="${DEST%/}/build/"
+	fi
+fi
+
+if [ ! -d "$SOURCE_DIR" ]; then
+	echo "Invalid source destination directory: $SOURCE_DIR"
+	exit 2
+fi
+if [ ! -d "$BUILD_DIR" ]; then
+	echo "Invalid build destination directory: $BUILD_DIR"
+	exit 3
+fi
+
+# Download and unzip the package
+cd "$SOURCE_DIR"
+if [ $SKIP_DOWNLOAD = false ]; then
+	echo "Downloading $PACKAGE_NAME to $SOURCE_DIR"
+	wget "$DOWNLOAD_LINK" -O "$PACKAGE_DIR_NAME.tar.gz" || exit 11
+	echo "Extracting $PACKAGE_NAME"
+	mkdir "$PACKAGE_DIR_NAME"
+	tar -xzf "$PACKAGE_DIR_NAME.tar.gz" -C "$PACKAGE_DIR_NAME" --strip-components=1 || exit 12
+	rm "$PACKAGE_DIR_NAME.tar.gz"
+fi
+
+# Run package installation
+if [ $SKIP_BUILD = false ]; then
+	echo "Compiling $PACKAGE_NAME"
+	cd "$PACKAGE_DIR_NAME"
+	./configure --enable-shared --with-pydebug --prefix="$BUILD_DIR" || exit 31
+	echo "Installing $PACKAGE_NAME"
+	if [ -z "$MAKE_ARG" ]
+	then
+		make || exit 32
+	else
+		make "$MAKE_ARG" || exit 32
+	fi 
+	make install || exit 33
+
+	# establish the "python" and "pip" symlinks
+	ln -s "$BUILD_DIR/bin/python3" "$BUILD_DIR/bin/python"
+	ln -s "$BUILD_DIR/bin/pip3" "$BUILD_DIR/bin/pip"
+
+	# pip install some needed python packages
+	export LD_LIBRARY_PATH="$BUILD_DIR/lib"
+	$BUILD_DIR/bin/pip3 install gnureadline h5py healpy iminuit matplotlib numpy pandas pynverse scipy || exit 34
+fi
+
+# Clean up source directory if requested
+if [ $CLEAN_SOURCE = true ]; then
+	echo "Removing $PACKAGE_NAME source directory from $SOURCE_DIR"
+	cd "$SOURCE_DIR"
+	rm -rf "$PACKAGE_DIR_NAME"
+fi
+
+echo "$PACKAGE_NAME installed in $BUILD_DIR"


### PR DESCRIPTION
This pull request adds a new frozen version to the cvmfs space: v3.0.0

This version is intended for use by those who wanted up-to-date software, but don't want the frequent recompilation that comes with using `trunk`. It mostly reflects the current `trunk` branch, with the software stack as it was in January/February 2021. The only minor change is a downgrade in Python to 3.8.5, in order to support libraries which haven't yet updated to 3.9 (TensorFlow in particular, though there may be others).