### PR TITLE
add tables and tqdm to python pip install list

### DIFF
--- a/builders/trunk/build_python3.sh
+++ b/builders/trunk/build_python3.sh
@@ -111,7 +111,7 @@ if [ $SKIP_BUILD = false ]; then
 
 	# pip install some needed python packages
 	export LD_LIBRARY_PATH="$BUILD_DIR/lib"
-	$BUILD_DIR/bin/pip3 install gnureadline h5py healpy iminuit matplotlib numpy pandas pynverse scipy || exit 34
+	$BUILD_DIR/bin/pip3 install gnureadline h5py healpy iminuit tables tqdm matplotlib numpy pandas pynverse scipy || exit 34
 fi
 
 # Clean up source directory if requested


### PR DESCRIPTION
This adds `tables` and `tqdm` to the list of packages pip installed by python. These have grown helpful to various code users.