### PR TITLE
Freeze the python packages that are pip installed in v4.1.0

### DIFF
--- a/builders/v4.1.0/build_python3.sh
+++ b/builders/v4.1.0/build_python3.sh
@@ -111,7 +111,7 @@ if [ $SKIP_BUILD = false ]; then
 
 	# pip install some needed python packages
 	export LD_LIBRARY_PATH="$BUILD_DIR/lib"
-	$BUILD_DIR/bin/pip3 install gnureadline h5py healpy iminuit matplotlib numpy pandas pynverse scipy || exit 34
+	$BUILD_DIR/bin/pip3 install gnureadline==8.2.13 h5py==3.14.0 healpy==1.17.3 iminuit==2.31.1 matplotlib==3.9.4 numpy==1.26.4 pandas==2.3.2 pynverse==0.1.4.6 scipy==1.13.1 || exit 34
 fi
 
 # Clean up source directory if requested


### PR DESCRIPTION
Motivated because pandas is failing the pip install at the moment. I got all these version numbers by running `pip list` in our current Centos7 build of the ARA Software. Indeed the pandas version on cobalt is 2.3.2 and the version that failed on the most recent software build was 2.3.3. 